### PR TITLE
Remove yellow -3 cards, since they don't exist

### DIFF
--- a/src/cards/CardApplierManager.test.ts
+++ b/src/cards/CardApplierManager.test.ts
@@ -39,32 +39,27 @@ describe('CardApplierManager', () => {
     applierManager.apply(lock, CardType.YELLOW_PLUS1)
     expect(lock.getNextDraw()).toBe(0)
     expect(lock.getCards().getRed()).toBe(101)
-    expect(lock.getCards().getYellow()).toBe(11)
+    expect(lock.getCards().getYellow()).toBe(9)
 
     applierManager.apply(lock, CardType.YELLOW_PLUS2)
     expect(lock.getNextDraw()).toBe(0)
     expect(lock.getCards().getRed()).toBe(103)
-    expect(lock.getCards().getYellow()).toBe(10)
+    expect(lock.getCards().getYellow()).toBe(8)
 
     applierManager.apply(lock, CardType.YELLOW_PLUS3)
     expect(lock.getNextDraw()).toBe(0)
     expect(lock.getCards().getRed()).toBe(106)
-    expect(lock.getCards().getYellow()).toBe(9)
+    expect(lock.getCards().getYellow()).toBe(7)
 
     applierManager.apply(lock, CardType.YELLOW_MINUS1)
     expect(lock.getNextDraw()).toBe(0)
     expect(lock.getCards().getRed()).toBe(105)
-    expect(lock.getCards().getYellow()).toBe(8)
+    expect(lock.getCards().getYellow()).toBe(6)
 
     applierManager.apply(lock, CardType.YELLOW_MINUS2)
     expect(lock.getNextDraw()).toBe(0)
     expect(lock.getCards().getRed()).toBe(103)
-    expect(lock.getCards().getYellow()).toBe(7)
-
-    applierManager.apply(lock, CardType.YELLOW_MINUS3)
-    expect(lock.getNextDraw()).toBe(0)
-    expect(lock.getCards().getRed()).toBe(100)
-    expect(lock.getCards().getYellow()).toBe(6)
+    expect(lock.getCards().getYellow()).toBe(5)
   })
 
   it('applies reset cards correctly', () => {

--- a/src/cards/appliers/YellowCardApplier.ts
+++ b/src/cards/appliers/YellowCardApplier.ts
@@ -7,8 +7,7 @@ const mapping = {
   [CardType.YELLOW_PLUS2.toString()]: 2,
   [CardType.YELLOW_PLUS3.toString()]: 3,
   [CardType.YELLOW_MINUS1.toString()]: -1,
-  [CardType.YELLOW_MINUS2.toString()]: -2,
-  [CardType.YELLOW_MINUS3.toString()]: -3
+  [CardType.YELLOW_MINUS2.toString()]: -2
 }
 
 class YellowCardApplier implements CardApplier {

--- a/src/model/CardType.ts
+++ b/src/model/CardType.ts
@@ -7,7 +7,6 @@ enum CardType {
   YELLOW_PLUS3 = 'YELLOW+3',
   YELLOW_MINUS1 = 'YELLOW-1',
   YELLOW_MINUS2 = 'YELLOW-2',
-  YELLOW_MINUS3 = 'YELLOW-3',
   FREEZE = 'FREEZE',
   DOUBLE = 'DOUBLE',
   RESET = 'RESET'
@@ -21,8 +20,7 @@ export const ALL_YELLOWS: CardType[] = [
   CardType.YELLOW_PLUS2,
   CardType.YELLOW_PLUS3,
   CardType.YELLOW_MINUS1,
-  CardType.YELLOW_MINUS2,
-  CardType.YELLOW_MINUS3
+  CardType.YELLOW_MINUS2
 ]
 
 export default CardType

--- a/src/model/Lock.test.ts
+++ b/src/model/Lock.test.ts
@@ -25,13 +25,12 @@ describe('Lock', () => {
     const cards: CardMapping = new CardMapping()
     cards.setCardsOfType(CardType.YELLOW_MINUS1, 1)
     cards.setCardsOfType(CardType.YELLOW_MINUS2, 2)
-    cards.setCardsOfType(CardType.YELLOW_MINUS3, 3)
     cards.setCardsOfType(CardType.YELLOW_PLUS1, 4)
     cards.setCardsOfType(CardType.YELLOW_PLUS2, 5)
     cards.setCardsOfType(CardType.YELLOW_PLUS3, 6)
 
     const lock = new Lock(lockConfig, cards)
 
-    expect(lock.getCards().getYellow()).toEqual(21)
+    expect(lock.getCards().getYellow()).toEqual(18)
   })
 })


### PR DESCRIPTION
What do you think? Should we keep it same as in the app, where we have the following yellow card types: -2, -1, +1, +2, +3?

I think it would make sense to keep it the same for now, we can still develop it further and add different types later on.